### PR TITLE
🤖 Remove obsolete pattern properties from track's `config.json` file

### DIFF
--- a/config.json
+++ b/config.json
@@ -16,9 +16,6 @@
     "indent_size": 4,
     "highlightjs_language": "ada"
   },
-  "ignore_pattern": "[Ee]xample",
-  "solution_pattern": "[Ee]xample",
-  "test_pattern": "[Tt]est",
   "exercises": {
     "concept": [],
     "practice": []


### PR DESCRIPTION
The `config.json` file previously supported the following keys:

- `test_pattern`
- `ignore_pattern`
- `solution_pattern`

These keys are now obsolete and have been replaced with the `files` property in `.meta/config.json` files (see [the docs](https://github.com/exercism/docs/blob/main/building/tracks/practice-exercises.md#file-metaconfigjson)).

To make things less confusing to maintainers, this PR removes those obsoleted pattern properties from the `config.json` files.

See https://github.com/exercism/v3-launch/issues/47